### PR TITLE
Refactor the constituency lookup component

### DIFF
--- a/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
+++ b/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
@@ -20,21 +20,6 @@ export async function GET(
 ) {
   console.log("IN SERVER FUNCTION");
 
-  // Throw errors some of the time.
-  //if ( Date.now() % 3 < 1) {
-  //  console.log("400 ERROR RESPONSE");
-  //  return new NextResponse("Error", { status: 400 })
-  //}
-
-  function sleep(ms: number) {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
-  }
-  console.log(`${new Date().toLocaleString()} - SLEEPING`);
-  await sleep(5000);
-  console.log(`${new Date().toLocaleString()} - FINISHED SLEEPING`);
-
   // console.log("***** FILES IN DATA DIRECTORY *****");
   // fs.readdirSync(path.join(process.cwd(), "data")).forEach((file: any) => {
   //   console.log(`- ${file}`);

--- a/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
+++ b/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
@@ -14,8 +14,20 @@ const dbPath = path.join(process.cwd(), "data", "postcodes.db");
 console.log(`***** dbPath is [${dbPath}] *****`);
 
 // TODO: Handle errors and return appropriate errorMessage useful for debugging...!
-export async function GET(request: NextRequest, { params }: { params: { postcode: string, address: string[] } }) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { postcode: string; address: string[] } },
+) {
   console.log("IN SERVER FUNCTION");
+  function sleep(ms: number) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  }
+  console.log(`${new Date().toLocaleString()} - SLEEPING`);
+  await sleep(5000);
+  console.log(`${new Date().toLocaleString()} - FINISHED SLEEPING`);
+
   const postcode = params.postcode;
   const addressSlug = params.address?.[0];
 

--- a/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
+++ b/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
@@ -19,6 +19,13 @@ export async function GET(
   { params }: { params: { postcode: string; address?: string[] } },
 ) {
   console.log("IN SERVER FUNCTION");
+
+  // Throw errors some of the time.
+  //if ( Date.now() % 3 < 1) {
+  //  console.log("400 ERROR RESPONSE");
+  //  return new NextResponse("Error", { status: 400 })
+  //}
+
   function sleep(ms: number) {
     return new Promise((resolve) => {
       setTimeout(resolve, ms);
@@ -27,9 +34,6 @@ export async function GET(
   console.log(`${new Date().toLocaleString()} - SLEEPING`);
   await sleep(5000);
   console.log(`${new Date().toLocaleString()} - FINISHED SLEEPING`);
-
-  const postcode = params.postcode;
-  const addressSlug = params.address?.[0];
 
   // console.log("***** FILES IN DATA DIRECTORY *****");
   // fs.readdirSync(path.join(process.cwd(), "data")).forEach((file: any) => {

--- a/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
+++ b/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
@@ -14,10 +14,11 @@ const dbPath = path.join(process.cwd(), "data", "postcodes.db");
 console.log(`***** dbPath is [${dbPath}] *****`);
 
 // TODO: Handle errors and return appropriate errorMessage useful for debugging...!
-export async function GET(request: NextRequest, { params }: { params: { postcode: string, address: string[] } }) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { postcode: string; address?: string[] } },
+) {
   console.log("IN SERVER FUNCTION");
-  const postcode = params.postcode;
-  const addressSlug = params.address?.[0];
 
   // console.log("***** FILES IN DATA DIRECTORY *****");
   // fs.readdirSync(path.join(process.cwd(), "data")).forEach((file: any) => {
@@ -25,13 +26,13 @@ export async function GET(request: NextRequest, { params }: { params: { postcode
   // });
 
   //read & normalize postcode
-  const normalizedPostcode = normalizePostcode(postcode);
+  const normalizedPostcode = normalizePostcode(params.postcode);
 
   //validate the postcode
   if (!normalizedPostcode || !validatePostcode.test(normalizedPostcode)) {
-    console.log(`Postcode ${postcode} is not valid!`);
+    console.log(`Postcode ${params.postcode} is not valid!`);
     const response: ConstituencyLookupResponse = {
-      postcode: postcode,
+      postcode: params.postcode,
       constituencies: [],
       errorCode: "POSTCODE_INVALID",
     };
@@ -66,8 +67,8 @@ export async function GET(request: NextRequest, { params }: { params: { postcode
   if (!constituencies || constituencies.length == 0) {
     console.log(`Postcode ${normalizedPostcode} not found in DB!`);
     const response: ConstituencyLookupResponse = {
-      postcode: postcode,
-      addressSlug: addressSlug,
+      postcode: params.postcode,
+      addressSlug: params.address?.[0],
       constituencies: [],
       errorCode: "POSTCODE_NOT_FOUND",
     };
@@ -77,8 +78,8 @@ export async function GET(request: NextRequest, { params }: { params: { postcode
   if (constituencies.length == 1) {
     console.log(`Single constituency found for postcode ${normalizedPostcode}`);
     const response: ConstituencyLookupResponse = {
-      postcode: postcode,
-      addressSlug: addressSlug,
+      postcode: params.postcode,
+      addressSlug: params.address?.[0],
       constituencies: constituencies,
     };
     return NextResponse.json(response);
@@ -89,8 +90,8 @@ export async function GET(request: NextRequest, { params }: { params: { postcode
       `Multiple constituencies found for postcode ${normalizedPostcode}`,
     );
     const response: ConstituencyLookupResponse = {
-      postcode: postcode,
-      addressSlug: addressSlug,
+      postcode: params.postcode,
+      addressSlug: params.address?.[0],
       constituencies: constituencies,
     };
     return NextResponse.json(response);

--- a/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
+++ b/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
@@ -1,3 +1,4 @@
+// import * as fs from 'fs';
 import { NextRequest, NextResponse } from "next/server";
 import sqlite3 from "sqlite3";
 import { open, Database } from "sqlite";
@@ -7,27 +8,21 @@ import { validatePostcode, normalizePostcode } from "@/utils/Postcodes";
 // Force using 'nodejs' rather than 'edge' - edge won't have the filesystem containing SQLite
 export const runtime = "nodejs";
 
-const fs = require("fs");
-
 // Declare the DB outside the func & lazy-load, so it can be cached across calls
 let db: Database | null = null;
 const dbPath = path.join(process.cwd(), "data", "postcodes.db");
 console.log(`***** dbPath is [${dbPath}] *****`);
 
 // TODO: Handle errors and return appropriate errorMessage useful for debugging...!
-// TODO: Next.js doesn't cache POSTs - potentially change to a GET of format:
-// constituency_lookup/{postcode}/{addressSlug}
-// which should enable caching
-export async function GET(request: NextRequest, context) {
+export async function GET(request: NextRequest, { params }: { params: { postcode: string, address: string[] } }) {
   console.log("IN SERVER FUNCTION");
-  console.log(request);
-  const postcode = context.params.postcode;
-  const addressSlug = context.params?.address?.[0];
+  const postcode = params.postcode;
+  const addressSlug = params.address?.[0];
 
-  console.log("***** FILES IN DATA DIRECTORY *****");
-  fs.readdirSync(path.join(process.cwd(), "data")).forEach((file: any) => {
-    console.log(file);
-  });
+  // console.log("***** FILES IN DATA DIRECTORY *****");
+  // fs.readdirSync(path.join(process.cwd(), "data")).forEach((file: any) => {
+  //   console.log(`- ${file}`);
+  // });
 
   //read & normalize postcode
   const normalizedPostcode = normalizePostcode(postcode);
@@ -67,8 +62,6 @@ export async function GET(request: NextRequest, context) {
     normalizedPostcode,
   );
   console.timeEnd("query-postcode-database");
-
-  console.log(`Found constituencues ${constituencies} from database`);
 
   if (!constituencies || constituencies.length == 0) {
     console.log(`Postcode ${normalizedPostcode} not found in DB!`);

--- a/app/globals.scss
+++ b/app/globals.scss
@@ -88,9 +88,9 @@ $bs-link-hover-color-rgb: 238, 102, 238;
 @import "bootstrap/scss/bootstrap";
 // @import "../node_modules/bootstrap/scss/bootstrap";
 
-/* GLOBAL DEFAULT STYLES */
+/***** GLOBAL DEFAULT STYLES *****/
 
-// Header
+/* HEADER */
 header {
   background-color: var(--bs-black);
   color: var(--bs-white);
@@ -107,7 +107,7 @@ header h1 {
   }
 }
 
-// Headings
+/* TEXT HEADINGS */
 h1,
 h2,
 h3,
@@ -119,7 +119,8 @@ h6 {
   text-transform: uppercase;
 }
 
-// Checkbox
+/* FORM INPUTS */
+// Set checkbox size & style
 input[type="checkbox"] {
   width: 22px;
   height: 22px;
@@ -148,7 +149,12 @@ button:focus {
   border-color: var(--bs-gray-600) !important;
 }
 
-// Party styles
+// Custom validation for postcode & email text inputs
+.invalid-text-greyed:invalid {
+  color: var(--bs-gray-600);
+}
+
+/* PARTY STYLES */
 h3.party {
   font-size: 8vmax;
   font-weight: 800;

--- a/components/constituency_lookup/ConstituencyLookup.tsx
+++ b/components/constituency_lookup/ConstituencyLookup.tsx
@@ -125,8 +125,6 @@ const initialFormState: FormData = {
   email: "",
 };
 
-let currentPostcode = "";
-
 const PostcodeLookup = () => {
   const router = useRouter();
 
@@ -142,13 +140,13 @@ const PostcodeLookup = () => {
 
   const [lastValidPostcode, setLastValidPostcode] = useState<string>("");
 
-  const currentPostcodeUseRef = useRef("");
+  const currentPostcode = useRef("");
 
   const lastSelectedConstituency = useMemo(() => {
     if (
       apiResponse &&
       apiResponse.constituencies?.length > 0 &&
-      apiResponse.postcode == currentPostcodeUseRef.current &&
+      apiResponse.postcode == currentPostcode.current &&
       formState.constituencyIndex !== false
     ) {
       return apiResponse.constituencies[formState.constituencyIndex];
@@ -157,19 +155,8 @@ const PostcodeLookup = () => {
     }
   },
     [apiResponse, formState.constituencyIndex]
-  )
-  let userConstituency: Constituency | null = null;
-
-  if (
-    apiResponse &&
-    apiResponse.constituencies &&
-    apiResponse.constituencies.length != 0 &&
-    apiResponse.postcode == lastValidPostcode &&
-    formState.constituencyIndex !== false
-  ) {
-    userConstituency = apiResponse.constituencies[formState.constituencyIndex];
-  }
-  console.log(`lastSelectedConstituency [${JSON.stringify(lastSelectedConstituency)}], userConstituency: [${JSON.stringify(userConstituency)}]`)
+  );
+  console.log(`lastSelectedConstituency [${JSON.stringify(lastSelectedConstituency)}]`);
 
   const lookupPostcode = async (
     postcode: string,
@@ -178,19 +165,17 @@ const PostcodeLookup = () => {
     setApiResponse(false);
 
     console.log("MAKING POSTCODE API CALL");
-    console.log(`currentPostcode [${currentPostcode}]`);
-    console.log(`currentPostcodeUseRef [${currentPostcodeUseRef.current}]`);
+    console.log(`currentPostcode [${currentPostcode.current}]`);
     console.log(`postcode [${postcode}]`);
     console.log(`lastValidPostcode [${lastValidPostcode}]`);
 
     const responseJson = await throttledApi(postcode, addressSlug);
 
     // The response postcode doesn't match the last one entered.
-    if (responseJson?.postcode !== currentPostcodeUseRef.current) {
+    if (responseJson?.postcode !== currentPostcode.current) {
       console.log("CURRENT POSTCODE DOESN'T MATCH RESPONSE");
       console.log(`responseJson?.postcode [${responseJson?.postcode}]`);
-      console.log(`currentPostcode [${currentPostcode}]`);
-      console.log(`currentPostcodeUseRef [${currentPostcodeUseRef.current}]`);
+      console.log(`currentPostcode [${currentPostcode.current}]`);
       console.log(`postcode [${postcode}]`);
       console.log(`lastValidPostcode [${lastValidPostcode}]`);
       return null;
@@ -198,8 +183,7 @@ const PostcodeLookup = () => {
 
     console.log("CURRENT POSTCODE DOES MATCH RESPONSE - UPDATING");
     console.log(`responseJson?.postcode [${responseJson?.postcode}]`);
-    console.log(`currentPostcode [${currentPostcode}]`);
-    console.log(`currentPostcodeUseRef [${currentPostcodeUseRef.current}]`);
+    console.log(`currentPostcode [${currentPostcode.current}]`);
     console.log(`postcode [${postcode}]`);
     console.log(`lastValidPostcode [${lastValidPostcode}]`);
 
@@ -227,14 +211,9 @@ const PostcodeLookup = () => {
     if (!validatePostcode.test(normalizedPostcode)) {
       return;
     } else {
-      // setLastValidPostcode(normalizedPostcode);
-    }
-    currentPostcode = normalizedPostcode;
-    currentPostcodeUseRef.current = normalizedPostcode;
-
-    if (normalizedPostcode != lastValidPostcode) {
       setLastValidPostcode(normalizedPostcode);
     }
+    currentPostcode.current = normalizedPostcode;
 
     // If the postcode looks valid, and it's not the same as the last postcode we looked
     // up in the API, pre-load the results so we can imediately show the constituency /

--- a/components/constituency_lookup/ConstituencyLookup.tsx
+++ b/components/constituency_lookup/ConstituencyLookup.tsx
@@ -51,10 +51,8 @@ const fetchApi = async (
     );
 
     if (response.ok) {
-      console.log("response OK");
       return response.json();
     } else {
-      console.log("response not ok");
       return null;
     }
   } catch {
@@ -73,7 +71,7 @@ const reqControl: ReqControl = {
   time: 0,
   timerID: null,
   lastLookup: null,
-  rateLimit: 7000,
+  rateLimit: 3000,
 };
 
 // throttled apiFetch
@@ -81,8 +79,6 @@ const throttledApi = async (
   postcode: string,
   addressSlug?: string,
 ): Promise<ConstituencyLookupResponse | null> => {
-  console.log("Throttled API request");
-
   //TODO handle address lookups in the cache if/when we use DemoClub API
   if (lookupCache.hasOwnProperty(postcode)) {
     const cached = await lookupCache[postcode];
@@ -121,9 +117,7 @@ const throttledApi = async (
       // If a request is cancelled we still need to resovle the promise.
       setTimeout(
         () => {
-          console.log("Checking for cancelled request:", cancelled);
           if (cancelled == true) {
-            console.log("request has been cancelled resolving promise");
             resolve(null);
           }
         },
@@ -176,9 +170,6 @@ const PostcodeLookup = () => {
       return null;
     }
   }, [apiResponse, formState.constituencyIndex]);
-  console.log(
-    `lastSelectedConstituency [${JSON.stringify(lastSelectedConstituency)}]`,
-  );
 
   const lookupConstituency = async (
     postcode: string,
@@ -187,16 +178,7 @@ const PostcodeLookup = () => {
     setApiResponse(false);
     setError(null);
 
-    console.log("MAKING POSTCODE API CALL:");
-    console.log(`request postcode [${postcode}]`);
-    console.log(`current validPostcode [${validPostcode.current}]`);
-
     const responseJson = await throttledApi(postcode, addressSlug);
-
-    console.log("API CALL RESPONSE:");
-    console.log(`request postcode [${postcode}]`);
-    console.log(`responseJson?.postcode [${responseJson?.postcode}]`);
-    console.log(`current validPostcode [${validPostcode.current}]`);
 
     if (postcode != validPostcode.current) {
       //This request no longer mathes the most recent.
@@ -221,8 +203,6 @@ const PostcodeLookup = () => {
       setApiResponse(false); // clear the spinner
       return null;
     }
-
-    console.log("RESPONSE MATCHES CURRENT - UPDATING");
 
     setApiResponse(responseJson);
     setError(responseJson.errorCode || null);
@@ -256,8 +236,9 @@ const PostcodeLookup = () => {
   };
 
   const submitForm = async () => {
-    console.log("Submitting form");
     if (lastSelectedConstituency) {
+      // TODO: Validate email & submit to AN form to subscribe them.
+      // TODO: Do we want/need a separate error field for email so we can show if BOTH postcode and email are invalid in one pass?
       router.push(`/constituencies/${lastSelectedConstituency.slug}`);
       return;
     }
@@ -279,9 +260,6 @@ const PostcodeLookup = () => {
     if (apiResponse.constituencies.length > 1 && !formState.constituencyIndex) {
       //TODO: Set error for unclear constituency
     }
-
-    // TODO: Validate email if emailOptIn is set
-    // TODO: Do we want/need a separate error field for email so we can show if BOTH postcode and email are invalid in one pass?
   };
 
   return (

--- a/components/constituency_lookup/ConstituencyLookup.tsx
+++ b/components/constituency_lookup/ConstituencyLookup.tsx
@@ -2,7 +2,16 @@
 
 import { useRouter } from "next/navigation";
 
-import { Container, Form, Button, FormCheck, Row, Col } from "react-bootstrap";
+import {
+  Container,
+  Form,
+  Button,
+  FormCheck,
+  Row,
+  Col,
+  Spinner,
+  InputGroup,
+} from "react-bootstrap";
 
 import {
   normalizePostcode,
@@ -25,21 +34,92 @@ const errorCodeToErrorMessage = (code: ErrorCode) => {
   }
 };
 
+const lookupCache: {
+  [key: string]: Promise<ConstituencyLookupResponse | null>;
+} = {};
+
+const fetchApi = async (
+  requestBody: ConstituencyLookupRequest,
+): Promise<ConstituencyLookupResponse | null> => {
+  try {
+    console.log("Making API call to constituency lookup route");
+    const response = await fetch("/api/constituency_lookup", {
+      method: "POST",
+      body: JSON.stringify(requestBody),
+    });
+
+    if (response.ok) {
+      lookupCache[requestBody.postcode] = response.json();
+      return lookupCache[requestBody.postcode];
+    } else {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+};
+
+type ReqControl = {
+  time: number;
+  timerID: ReturnType<typeof setTimeout> | null;
+  rateLimit: number;
+};
+
+const reqControl: ReqControl = {
+  time: 0,
+  timerID: null,
+  rateLimit: 3000,
+};
+
+// throttled apiFetch
+const throttledApi = async (
+  requestBody: ConstituencyLookupRequest,
+): Promise<ConstituencyLookupResponse | null> => {
+  if (lookupCache.hasOwnProperty(requestBody.postcode)) {
+    const cached = await lookupCache[requestBody.postcode];
+    if (cached !== null) {
+      return cached; //don't want to cache and return an error!
+    }
+  }
+
+  if (reqControl.timerID) {
+    clearTimeout(reqControl.timerID);
+  }
+
+  if (reqControl.time + reqControl.rateLimit < Date.now()) {
+    //more than rate limit ms since last request
+    reqControl.time = Date.now();
+    lookupCache[requestBody.postcode] = fetchApi(requestBody);
+  } else {
+    //need to delay the request
+    lookupCache[requestBody.postcode] = new Promise((resolve) => {
+      reqControl.timerID = setTimeout(
+        () => {
+          reqControl.timerID = null;
+          reqControl.time = Date.now();
+          resolve(fetchApi(requestBody));
+        },
+        reqControl.rateLimit - (Date.now() - reqControl.time),
+      );
+    });
+  }
+
+  return lookupCache[requestBody.postcode];
+};
+
 type FormData = {
-  postcode: string;
   emailOptIn: boolean;
-  constituencySlug: string;
   addressSlug: string;
   email: string;
 };
 
 const initialFormState: FormData = {
-  postcode: "",
   emailOptIn: false,
-  constituencySlug: "",
   addressSlug: "",
   email: "",
 };
+
+let currentPostcode = "";
 
 const PostcodeLookup = () => {
   const router = useRouter();
@@ -49,123 +129,111 @@ const PostcodeLookup = () => {
   // Was hitting into this issue: https://github.com/vercel/next.js/issues/55919
 
   const [formState, setFormState] = useState<FormData>(initialFormState);
-  const [apiResponse, setApiResponse] =
-    useState<ConstituencyLookupResponse | null>(null);
-  const [apiInProgress, setApiInProgress] = useState<boolean>(false);
+  const [apiResponse, setApiResponse] = useState<
+    ConstituencyLookupResponse | false | null
+  >(null);
   const [error, setError] = useState<ErrorCode | null>(null);
 
-  const callApi = async (userPostcode: string, addressSlug?: string) => {
-    // Avoid calling the API multiple time concurrently from fast user input...
-    if (apiInProgress) {
-      console.log("Skipping concurrent API call");
-      return;
+  const [validPostcode, setValidPostcode] = useState<boolean>(false);
+  const [lastValidPcode, setLastValidPcode] = useState<string>("");
+  const [constituencyIdx, setConstituencyIdx] = useState<number | false>(false);
+
+  let userConstituency: Constituency | null = null;
+
+  if (
+    apiResponse &&
+    apiResponse.constituencies &&
+    apiResponse.constituencies.length != 0 &&
+    apiResponse.postcode == lastValidPcode &&
+    constituencyIdx !== false
+  ) {
+    userConstituency = apiResponse.constituencies[constituencyIdx];
+  }
+
+  const lookupPostcode = async (
+    userPostcode: string,
+    addressSlug?: string,
+  ): Promise<ConstituencyLookupResponse | null> => {
+    setApiResponse(false);
+
+    const requestBody: ConstituencyLookupRequest = {
+      postcode: userPostcode,
+      addressSlug: addressSlug,
+    };
+    const responseJson = await throttledApi(requestBody);
+
+    // The response postcode doesn't match the last one entered.
+    if (responseJson?.postcode !== currentPostcode) {
+      return null;
     }
 
-    setApiInProgress(true);
+    if (responseJson === null) {
+      //TODO set a server error
+    } else {
+      setApiResponse(responseJson);
 
-    try {
-      const requestBody: ConstituencyLookupRequest = {
-        postcode: userPostcode,
-        addressSlug: addressSlug,
-      };
-      console.log("Making API call to constituency lookup route");
-      const response = await fetch("/api/constituency_lookup", {
-        method: "POST",
-        body: JSON.stringify(requestBody),
-      });
-
-      if (response.ok) {
-        const responseJson: ConstituencyLookupResponse = await response.json();
-        setApiResponse(responseJson);
-        setError(responseJson.errorCode || null);
+      if (responseJson.constituencies.length == 1) {
+        setConstituencyIdx(0);
       } else {
-        setError("SERVER_ERROR");
+        setConstituencyIdx(false);
       }
-    } catch {
-      setError("SERVER_ERROR");
+      setError(responseJson.errorCode || null);
     }
 
-    setApiInProgress(false);
+    return responseJson;
   };
 
   const postcodeChanged = async (userPostcode: string) => {
     // Update the stored / displayed postcode
-    setFormState({ ...formState, postcode: userPostcode });
 
     const normalizedPostcode = normalizePostcode(userPostcode);
+
+    if (!validatePostcode.test(normalizedPostcode)) {
+      setValidPostcode(false);
+      return;
+    } else {
+      setValidPostcode(true);
+    }
+    currentPostcode = normalizedPostcode;
+
+    if (normalizedPostcode != lastValidPcode) {
+      setLastValidPcode(normalizedPostcode);
+    }
 
     // If the postcode looks valid, and it's not the same as the last postcode we looked
     // up in the API, pre-load the results so we can imediately show the constituency /
     // address drop-down if necessary.
-    if (
-      validatePostcode.test(normalizedPostcode) &&
-      (!apiResponse || apiResponse.postcode != normalizedPostcode)
-    ) {
-      // Postcode has changed, so leave out the addressSlug in the API call - even if
-      // one is/was selected, it's a different postcode now, so irrelevant!
-      await callApi(normalizedPostcode);
-    }
+    await lookupPostcode(normalizedPostcode);
   };
 
   const submitForm = async () => {
-    const normalizedPostcode = normalizePostcode(formState.postcode);
+    console.log("Submitting form");
+    if (userConstituency) {
+      router.push(`/constituencies/${userConstituency.slug}`);
+      return;
+    }
 
     // VALIDATION
-    if (!normalizedPostcode || !validatePostcode.test(normalizedPostcode)) {
+    // no postcode or invalid postcode
+    if (
+      !lastValidPcode ||
+      !validatePostcode.test(lastValidPcode) ||
+      !apiResponse ||
+      !apiResponse.constituencies ||
+      apiResponse.constituencies.length == 0
+    ) {
       // User hasn't input anything or invalid postcode
-      setApiResponse(null);
       setError("POSTCODE_INVALID");
       return;
     }
 
+    //not selected constituency or address
+    if (apiResponse.constituencies.length > 1 && !constituencyIdx) {
+      //TODO: Set error for unclear constituency
+    }
+
     // TODO: Validate email if emailOptIn is set
     // TODO: Do we want/need a separate error field for email so we can show if BOTH postcode and email are invalid in one pass?
-
-    // CALL API IF NECESSARY
-    if (!apiResponse || apiResponse.postcode != normalizedPostcode) {
-      // The postcode SHOULD have already been looked up by the postcodeChanged handler,
-      // but it's possible that a slow pre-load API call blocked a subsequent postcode
-      // change by the user (because we prevent concurrent API calls). If the form
-      // postcode and last API postcode don't match, call the API.
-      console.log("SUBMIT HANDLER: postcode changed, calling API");
-      await callApi(formState.postcode);
-    } else if (
-      formState.addressSlug &&
-      (!apiResponse || apiResponse.addressSlug != formState.addressSlug)
-    ) {
-      // Postcode has not changed, but the selected address has, so we need to call the
-      // API to find the constituency for this address
-      await callApi(formState.postcode, formState.addressSlug);
-      console.log("SUBMIT HANDLER: addressSlug changed, calling API");
-    }
-
-    // SHOW ERRORS
-    if (!apiResponse) {
-      // TODO: Show error to user based on failed API call!
-      return;
-    }
-
-    if (apiResponse.errorCode) {
-      // Error - do nothing (component will automatically show the error)
-      return;
-    }
-
-    if (apiResponse.constituencies.length == 1) {
-      // Only one constituency returned by API - redirect
-      // TODO: Subscribe email via ActionNetwork API now their constituency is known
-      console.log(
-        "SUBMIT HANDLER: Only one constituency from API, redirecting",
-      );
-      router.push(`/constituencies/${apiResponse.constituencies[0].slug}`);
-    } else if (formState.constituencySlug) {
-      // User has explicitly selected their constituency from the drop-down - redirect
-      // TODO: Subscribe email via ActionNetwork API now their constituency is known
-      console.log("SUBMIT HANDLER: User selected constituency, redirecting");
-      router.push(`/constituencies/${formState.constituencySlug}`);
-    }
-
-    // If API returned multiple possible constituencies, the component will
-    // automatically show a select for the constituencies or addresses
   };
 
   return (
@@ -178,16 +246,26 @@ const PostcodeLookup = () => {
         <p className="fw-bold text-900">
           Vote tactically at the General Election
         </p>
-
-        <Form.Control
-          name="postcode"
-          size="lg"
-          type="text"
-          placeholder="Your Postcode"
-          pattern={postcodeInputPattern}
-          onChange={(e) => postcodeChanged(e.target.value)}
-          className="my-3"
-        />
+        <InputGroup className="my-3">
+          <Form.Control
+            name="postcode"
+            size="lg"
+            type="text"
+            placeholder="Your Postcode"
+            pattern={postcodeInputPattern}
+            onChange={(e) => postcodeChanged(e.target.value)}
+            className={`my-3" ${validPostcode ? "" : "text-black-50"}`}
+          />
+          {userConstituency && (
+            <InputGroup.Text>
+              {!userConstituency?.name
+                ? ""
+                : userConstituency.name.length < 31
+                ? userConstituency.name
+                : userConstituency.name.substring(0, 27) + "..."}
+            </InputGroup.Text>
+          )}
+        </InputGroup>
 
         {error && (
           <p className="fw-bold fst-italic">{errorCodeToErrorMessage(error)}</p>
@@ -204,15 +282,13 @@ const PostcodeLookup = () => {
               name="constituency"
               size="lg"
               defaultValue=""
-              onChange={(e) =>
-                setFormState({ ...formState, constituencySlug: e.target.value })
-              }
+              onChange={(e) => setConstituencyIdx(parseInt(e.target.value))}
             >
               <option selected disabled value="" style={{ display: "none" }}>
                 Select Constituency
               </option>
-              {apiResponse.constituencies.map((c) => (
-                <option key={c.slug} value={c.slug}>
+              {apiResponse.constituencies.map((c, idx) => (
+                <option key={c.slug} value={idx}>
                   {c.name}
                 </option>
               ))}
@@ -274,9 +350,21 @@ const PostcodeLookup = () => {
               variant="light"
               size="lg"
               type="submit"
-              disabled={apiInProgress}
-              aria-disabled={apiInProgress}
+              disabled={!userConstituency}
+              aria-disabled={!userConstituency}
             >
+              {apiResponse === false && (
+                <>
+                  <Spinner
+                    as="span"
+                    animation="border"
+                    size="sm"
+                    role="status"
+                    area-hidden="true"
+                  />
+                  <span className="visually-hidden">Loading...</span>{" "}
+                </>
+              )}
               <span className={`${rubik.className} fw-bold`}>Go</span>
             </Button>
           </Col>

--- a/components/constituency_lookup/ConstituencyLookup.tsx
+++ b/components/constituency_lookup/ConstituencyLookup.tsx
@@ -46,8 +46,8 @@ const fetchApi = async (
     console.log("Making API call to constituency lookup route");
     const response = await fetch(
       "/api/constituency_lookup/" +
-      postcode +
-      (addressSlug ? "/" + addressSlug : ""),
+        postcode +
+        (addressSlug ? "/" + addressSlug : ""),
     );
 
     if (response.ok) {
@@ -153,10 +153,10 @@ const PostcodeLookup = () => {
     } else {
       return null;
     }
-  },
-    [apiResponse, formState.constituencyIndex]
+  }, [apiResponse, formState.constituencyIndex]);
+  console.log(
+    `lastSelectedConstituency [${JSON.stringify(lastSelectedConstituency)}]`,
   );
-  console.log(`lastSelectedConstituency [${JSON.stringify(lastSelectedConstituency)}]`);
 
   const lookupPostcode = async (
     postcode: string,
@@ -276,8 +276,8 @@ const PostcodeLookup = () => {
               {!lastSelectedConstituency?.name
                 ? ""
                 : lastSelectedConstituency.name.length < 31
-                  ? lastSelectedConstituency.name
-                  : lastSelectedConstituency.name.substring(0, 27) + "..."}
+                ? lastSelectedConstituency.name
+                : lastSelectedConstituency.name.substring(0, 27) + "..."}
             </InputGroup.Text>
           )}
         </InputGroup>
@@ -297,10 +297,12 @@ const PostcodeLookup = () => {
               name="constituency"
               size="lg"
               defaultValue=""
-              onChange={(e) => setFormState({
-                ...formState,
-                constituencyIndex: parseInt(e.target.value),
-              })}
+              onChange={(e) =>
+                setFormState({
+                  ...formState,
+                  constituencyIndex: parseInt(e.target.value),
+                })
+              }
             >
               <option selected disabled value="" style={{ display: "none" }}>
                 Select Constituency
@@ -401,7 +403,7 @@ const PostcodeLookup = () => {
           </Col>
         </Row>
       </Form>
-    </Container >
+    </Container>
   );
 };
 

--- a/components/constituency_lookup/types.tsx
+++ b/components/constituency_lookup/types.tsx
@@ -14,11 +14,6 @@ type Address = {
 
 type ErrorCode = "POSTCODE_INVALID" | "POSTCODE_NOT_FOUND" | "SERVER_ERROR";
 
-type ConstituencyLookupRequest = {
-  postcode: string;
-  addressSlug?: string;
-};
-
 type ConstituencyLookupResponse = {
   postcode: string;
   addressSlug?: string;


### PR DESCRIPTION
* Allow concurrent calls to lookupPostcode:
* Calls are throttled (typing lots of postcodes will just lookup the last one)
* Results are cached

* Put a spinner on the button whilst requests are in progress
* Display the currently chosen constituency.
* Gray out postcodes which are invalid in the box.