### PR TITLE
Refactor lookup component - experiments

### DIFF
--- a/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
+++ b/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
@@ -14,8 +14,20 @@ const dbPath = path.join(process.cwd(), "data", "postcodes.db");
 console.log(`***** dbPath is [${dbPath}] *****`);
 
 // TODO: Handle errors and return appropriate errorMessage useful for debugging...!
-export async function GET(request: NextRequest, { params }: { params: { postcode: string, address: string[] } }) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { postcode: string; address: string[] } },
+) {
   console.log("IN SERVER FUNCTION");
+  function sleep(ms: number) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  }
+  console.log(`${new Date().toLocaleString()} - SLEEPING`);
+  await sleep(5000);
+  console.log(`${new Date().toLocaleString()} - FINISHED SLEEPING`);
+
   const postcode = params.postcode;
   const addressSlug = params.address?.[0];
 

--- a/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
+++ b/app/api/constituency_lookup/[postcode]/[[...address]]/route.ts
@@ -19,6 +19,13 @@ export async function GET(
   { params }: { params: { postcode: string; address?: string[] } },
 ) {
   console.log("IN SERVER FUNCTION");
+
+  // Throw errors some of the time.
+  //if ( Date.now() % 3 < 1) {
+  //  console.log("400 ERROR RESPONSE");
+  //  return new NextResponse("Error", { status: 400 })
+  //}
+
   function sleep(ms: number) {
     return new Promise((resolve) => {
       setTimeout(resolve, ms);
@@ -27,9 +34,6 @@ export async function GET(
   console.log(`${new Date().toLocaleString()} - SLEEPING`);
   await sleep(5000);
   console.log(`${new Date().toLocaleString()} - FINISHED SLEEPING`);
-
-  const postcode = params.postcode;
-  const addressSlug = params.address?.[0];
 
   // console.log("***** FILES IN DATA DIRECTORY *****");
   // fs.readdirSync(path.join(process.cwd(), "data")).forEach((file: any) => {

--- a/app/globals.scss
+++ b/app/globals.scss
@@ -88,9 +88,9 @@ $bs-link-hover-color-rgb: 238, 102, 238;
 @import "bootstrap/scss/bootstrap";
 // @import "../node_modules/bootstrap/scss/bootstrap";
 
-/* GLOBAL DEFAULT STYLES */
+/***** GLOBAL DEFAULT STYLES *****/
 
-// Header
+/* HEADER */
 header {
   background-color: var(--bs-black);
   color: var(--bs-white);
@@ -107,7 +107,7 @@ header h1 {
   }
 }
 
-// Headings
+/* TEXT HEADINGS */
 h1,
 h2,
 h3,
@@ -119,7 +119,8 @@ h6 {
   text-transform: uppercase;
 }
 
-// Checkbox
+/* FORM INPUTS */
+// Set checkbox size & style
 input[type="checkbox"] {
   width: 22px;
   height: 22px;
@@ -148,7 +149,12 @@ button:focus {
   border-color: var(--bs-gray-600) !important;
 }
 
-// Party styles
+// Custom validation for postcode & email text inputs
+.invalid-text-greyed:invalid {
+  color: var(--bs-gray-600);
+}
+
+/* PARTY STYLES */
 h3.party {
   font-size: 8vmax;
   font-weight: 800;

--- a/components/constituency_lookup/ConstituencyLookup.tsx
+++ b/components/constituency_lookup/ConstituencyLookup.tsx
@@ -125,8 +125,6 @@ const initialFormState: FormData = {
   email: "",
 };
 
-let currentPostcode = "";
-
 const PostcodeLookup = () => {
   const router = useRouter();
 
@@ -142,13 +140,13 @@ const PostcodeLookup = () => {
 
   const [lastValidPostcode, setLastValidPostcode] = useState<string>("");
 
-  const currentPostcodeUseRef = useRef("");
+  const currentPostcode = useRef("");
 
   const lastSelectedConstituency = useMemo(() => {
     if (
       apiResponse &&
       apiResponse.constituencies?.length > 0 &&
-      apiResponse.postcode == currentPostcodeUseRef.current &&
+      apiResponse.postcode == currentPostcode.current &&
       formState.constituencyIndex !== false
     ) {
       return apiResponse.constituencies[formState.constituencyIndex];
@@ -157,19 +155,8 @@ const PostcodeLookup = () => {
     }
   },
     [apiResponse, formState.constituencyIndex]
-  )
-  let userConstituency: Constituency | null = null;
-
-  if (
-    apiResponse &&
-    apiResponse.constituencies &&
-    apiResponse.constituencies.length != 0 &&
-    apiResponse.postcode == lastValidPostcode &&
-    formState.constituencyIndex !== false
-  ) {
-    userConstituency = apiResponse.constituencies[formState.constituencyIndex];
-  }
-  console.log(`lastSelectedConstituency [${JSON.stringify(lastSelectedConstituency)}], userConstituency: [${JSON.stringify(userConstituency)}]`)
+  );
+  console.log(`lastSelectedConstituency [${JSON.stringify(lastSelectedConstituency)}]`);
 
   const lookupPostcode = async (
     postcode: string,
@@ -178,19 +165,17 @@ const PostcodeLookup = () => {
     setApiResponse(false);
 
     console.log("MAKING POSTCODE API CALL");
-    console.log(`currentPostcode [${currentPostcode}]`);
-    console.log(`currentPostcodeUseRef [${currentPostcodeUseRef.current}]`);
+    console.log(`currentPostcode [${currentPostcode.current}]`);
     console.log(`postcode [${postcode}]`);
     console.log(`lastValidPostcode [${lastValidPostcode}]`);
 
     const responseJson = await throttledApi(postcode, addressSlug);
 
     // The response postcode doesn't match the last one entered.
-    if (responseJson?.postcode !== currentPostcodeUseRef.current) {
+    if (responseJson?.postcode !== currentPostcode.current) {
       console.log("CURRENT POSTCODE DOESN'T MATCH RESPONSE");
       console.log(`responseJson?.postcode [${responseJson?.postcode}]`);
-      console.log(`currentPostcode [${currentPostcode}]`);
-      console.log(`currentPostcodeUseRef [${currentPostcodeUseRef.current}]`);
+      console.log(`currentPostcode [${currentPostcode.current}]`);
       console.log(`postcode [${postcode}]`);
       console.log(`lastValidPostcode [${lastValidPostcode}]`);
       return null;
@@ -198,8 +183,7 @@ const PostcodeLookup = () => {
 
     console.log("CURRENT POSTCODE DOES MATCH RESPONSE - UPDATING");
     console.log(`responseJson?.postcode [${responseJson?.postcode}]`);
-    console.log(`currentPostcode [${currentPostcode}]`);
-    console.log(`currentPostcodeUseRef [${currentPostcodeUseRef.current}]`);
+    console.log(`currentPostcode [${currentPostcode.current}]`);
     console.log(`postcode [${postcode}]`);
     console.log(`lastValidPostcode [${lastValidPostcode}]`);
 
@@ -227,14 +211,9 @@ const PostcodeLookup = () => {
     if (!validatePostcode.test(normalizedPostcode)) {
       return;
     } else {
-      // setLastValidPostcode(normalizedPostcode);
-    }
-    currentPostcode = normalizedPostcode;
-    currentPostcodeUseRef.current = normalizedPostcode;
-
-    if (normalizedPostcode != lastValidPostcode) {
       setLastValidPostcode(normalizedPostcode);
     }
+    currentPostcode.current = normalizedPostcode;
 
     // If the postcode looks valid, and it's not the same as the last postcode we looked
     // up in the API, pre-load the results so we can imediately show the constituency /

--- a/components/constituency_lookup/ConstituencyLookup.tsx
+++ b/components/constituency_lookup/ConstituencyLookup.tsx
@@ -46,8 +46,8 @@ const fetchApi = async (
     console.log("Making API call to constituency lookup route");
     const response = await fetch(
       "/api/constituency_lookup/" +
-      postcode +
-      (addressSlug ? "/" + addressSlug : ""),
+        postcode +
+        (addressSlug ? "/" + addressSlug : ""),
     );
 
     if (response.ok) {
@@ -153,10 +153,10 @@ const PostcodeLookup = () => {
     } else {
       return null;
     }
-  },
-    [apiResponse, formState.constituencyIndex]
+  }, [apiResponse, formState.constituencyIndex]);
+  console.log(
+    `lastSelectedConstituency [${JSON.stringify(lastSelectedConstituency)}]`,
   );
-  console.log(`lastSelectedConstituency [${JSON.stringify(lastSelectedConstituency)}]`);
 
   const lookupPostcode = async (
     postcode: string,
@@ -276,8 +276,8 @@ const PostcodeLookup = () => {
               {!lastSelectedConstituency?.name
                 ? ""
                 : lastSelectedConstituency.name.length < 31
-                  ? lastSelectedConstituency.name
-                  : lastSelectedConstituency.name.substring(0, 27) + "..."}
+                ? lastSelectedConstituency.name
+                : lastSelectedConstituency.name.substring(0, 27) + "..."}
             </InputGroup.Text>
           )}
         </InputGroup>
@@ -297,10 +297,12 @@ const PostcodeLookup = () => {
               name="constituency"
               size="lg"
               defaultValue=""
-              onChange={(e) => setFormState({
-                ...formState,
-                constituencyIndex: parseInt(e.target.value),
-              })}
+              onChange={(e) =>
+                setFormState({
+                  ...formState,
+                  constituencyIndex: parseInt(e.target.value),
+                })
+              }
             >
               <option selected disabled value="" style={{ display: "none" }}>
                 Select Constituency
@@ -401,7 +403,7 @@ const PostcodeLookup = () => {
           </Col>
         </Row>
       </Form>
-    </Container >
+    </Container>
   );
 };
 


### PR DESCRIPTION
Main changes:

1. `useRef` for `currentPostcode` - more 'React-y' way of doing it rather than var declared outside the component (and updates to a `useRef` variable aren't queued behind other state changes, so we don't have the timing issues associated with tracking it thru `useState`).
2. `useMemo` for storing selected (or only) constituency. This means that rather than recalculating this on every render, it's only recalculated when an input to the calculation changes
3. Remove the `validPostcode` state - only used to change the style of the text input, so we can use pure CSS for this (the HTML validation already uses the same regex as we're using for validation anyway)
4. Shift `constituencyIdx` into the `formState` rather than needing it's own separate state var

**TODO**: Currently lots of debugging logs + a sleep in the server-side postcode lookup to simulate a slow speed, so easier to see potential timing issues