### PR TITLE
add checking for no constituency data to handle bad slugs

### DIFF
--- a/app/constituencies/[slug]/page.tsx
+++ b/app/constituencies/[slug]/page.tsx
@@ -29,15 +29,17 @@ export default async function ConstituencyPage({
     (c: ConstituencyData) => c.constituencyIdentifiers.slug === params.slug,
   )[0];
 
-  constituencyData.impliedPreviousResult.partyVoteResults.sort(
-    // sort implied results on votePercent instead
-    // of raw so nonVoters stay last.
-    (a, b) => b.votePercent - a.votePercent,
-  );
+  if (constituencyData) {
+    constituencyData.impliedPreviousResult.partyVoteResults.sort(
+      // sort implied results on votePercent instead
+      // of raw so nonVoters stay last.
+      (a, b) => b.votePercent - a.votePercent,
+    );
 
-  constituencyData.pollingResults.partyVoteResults.sort(
-    (a, b) => b.votePercent - a.votePercent,
-  );
+    constituencyData.pollingResults.partyVoteResults.sort(
+      (a, b) => b.votePercent - a.votePercent,
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
When I moved the sort out to the parent constituency component I didn't handle the case where the constituency was missing. Doh!